### PR TITLE
Add library.properties metadata file

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,0 +1,10 @@
+name=LC75823
+version=0.0.0
+author=Fırat SOYGÜL
+maintainer=Fırat SOYGÜL
+sentence=For the LC75823 LCD driver.
+paragraph=
+category=Display
+url=https://github.com/firatsoygul/LC75823
+architectures=*
+includes=LC75823.h


### PR DESCRIPTION
Libraries in the Arduino Library 1.5 format (source files under the src subfolder) are required to have a library.properties file in the root folder. If this file is not present the library is not recognized by the Arduino IDE.

This file is also required for inclusion in the [Arduino Library Manager index](https://github.com/arduino/Arduino/wiki/Library-Manager-FAQ).

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#library-metadata